### PR TITLE
fix: TimeBarChartとMetroBarChartのthis型推論対応

### DIFF
--- a/components/MetroBarChart.vue
+++ b/components/MetroBarChart.vue
@@ -25,24 +25,35 @@
 <script lang="ts">
 import Vue from 'vue'
 import { ChartOptions, ChartData } from 'chart.js'
+import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import DataView from '@/components/DataView.vue'
 
 export type DataType = {
   value: string
 }
-
-export default Vue.extend<
-  {},
-  {},
-  {},
-  {
-    chartData: ChartData
-    chartOption: ChartOptions
-    title: string
-    titleId: string
-    date: string
+type Data = {}
+type Methods = {}
+type Computed = {
+  displayData: {
+    labels: (string | undefined)[]
+    datasets: object
   }
->({
+}
+type Props = {
+  chartData: ChartData
+  chartOption: ChartOptions
+  title: string
+  titleId: string
+  date: string
+}
+
+const options: ThisTypedComponentOptionsWithRecordProps<
+  Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = {
   components: { DataView },
   props: {
     title: {
@@ -78,5 +89,7 @@ export default Vue.extend<
       }
     }
   }
-})
+}
+
+export default Vue.extend(options)
 </script>

--- a/components/TimeBarChart.vue
+++ b/components/TimeBarChart.vue
@@ -19,6 +19,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { ChartData, ChartTooltipItem } from 'chart.js'
+import { ThisTypedComponentOptionsWithRecordProps } from 'vue/types/options'
 import { GraphDataType } from '@/utils/formatGraph'
 import DataView from '@/components/DataView.vue'
 import DataSelector from '@/components/DataSelector.vue'
@@ -26,24 +27,62 @@ import DataViewBasicInfoPanel from '@/components/DataViewBasicInfoPanel.vue'
 
 type Data = {
   dataKind: 'transition' | 'cumulative'
-  displayCumulativeRatio: number
-  displayTransitionRatio: number
 }
-
 type Methods = {
   formatDayBeforeRatio: (dayBeforeRatio: number) => string
 }
-
-type PropTypes = {
-  chartData: GraphDataType[]
+type Computed = {
+  displayCumulativeRatio: string
+  displayTransitionRatio: string
+  displayInfo: {
+    lText: string
+    sText: string
+    unit: string
+  }
+  displayData: {
+    labels: string[]
+    datasets: {
+      label: 'transition' | 'cumulative'
+      data: number[]
+      backgroundColor: string
+      borderWidth: number
+    }[]
+  }
+  displayOption: {
+    tooltips: {
+      displayColors: boolean
+      callbacks: {
+        label(tooltipItem: ChartTooltipItem): string
+        title(
+          tooltipItem: ChartTooltipItem[],
+          data: ChartData
+        ): string | undefined
+      }
+    }
+    responsive: boolean
+    maintainAspectRatio: boolean
+    legend: {
+      display: boolean
+    }
+    scales: object
+  }
+}
+type Props = {
   title: string
   titleId: string
+  chartData: GraphDataType[]
   date: string
   unit: string
   url: string
 }
 
-export default Vue.extend<Data, Methods, {}, PropTypes>({
+const options: ThisTypedComponentOptionsWithRecordProps<
+  Vue,
+  Data,
+  Methods,
+  Computed,
+  Props
+> = {
   components: { DataView, DataSelector, DataViewBasicInfoPanel },
   props: {
     title: {
@@ -55,7 +94,7 @@ export default Vue.extend<Data, Methods, {}, PropTypes>({
       default: ''
     },
     chartData: {
-      type: Object,
+      type: Array,
       default: () => []
     },
     date: {
@@ -72,17 +111,15 @@ export default Vue.extend<Data, Methods, {}, PropTypes>({
     }
   },
   data: () => ({
-    dataKind: 'transition',
-    displayCumulativeRatio: 0,
-    displayTransitionRatio: 0
+    dataKind: 'transition'
   }),
   computed: {
-    displayCumulativeRatio(): string {
+    displayCumulativeRatio() {
       const lastDay = this.chartData.slice(-1)[0].cumulative
       const lastDayBefore = this.chartData.slice(-2)[0].cumulative
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)
     },
-    displayTransitionRatio(): string {
+    displayTransitionRatio() {
       const lastDay = this.chartData.slice(-1)[0].transition
       const lastDayBefore = this.chartData.slice(-2)[0].transition
       return this.formatDayBeforeRatio(lastDay - lastDayBefore)
@@ -105,7 +142,7 @@ export default Vue.extend<Data, Methods, {}, PropTypes>({
         unit: this.unit
       }
     },
-    displayData(): ChartData {
+    displayData() {
       if (this.dataKind === 'transition') {
         return {
           labels: this.chartData.map(d => {
@@ -210,5 +247,7 @@ export default Vue.extend<Data, Methods, {}, PropTypes>({
       }
     }
   }
-})
+}
+
+export default Vue.extend(options)
 </script>


### PR DESCRIPTION
## 📝 関連issue
- https://github.com/tokyo-metropolitan-gov/covid19/issues/621 

## ⛏ 変更内容
https://github.com/tokyo-metropolitan-gov/covid19/pull/696 のPR内容の中で、`TimeBarChart.vue` がVue Warningを出していたので解消したところ、thisの型推論を反映させるのが大変そうだったので、修正しました。

- Vue.Extendのoptionとして `ThisTypedComponentOptionsWithRecordProps<>` の型を持つように変更
- 各computedの型を詳細化
- 同様の方法で、 `MetroBarChart.vue` をrefactoring

## 📸 スクリーンショット
UI変更はありません